### PR TITLE
Update README to reflect nvcc location requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You also need a CUDA-ready GPU. We have tested this code on an Nvidia Titan Xp G
 
 ## Installing
 
-Before all else, make sure that you have the `g++` and `nvcc` compilers available from the command line.
+Before all else, make sure that you have the `g++` compiler available from the command line, and the `nvcc` compiler availible at path `/usr/local/cuda/bin/nvcc`.
 
 Then, open julia and type `]` to enter Package mode:
 


### PR DESCRIPTION
Commit 67660b5667265ea68c5a13caa438da2c59ccadde changed the build script to use a full path for the location of `nvcc` instead of assuming it is in the system PATH. I noticed this when installing the package, since my system had `nvcc` installed at `/opt/cuda/bin/nvcc` instead. This PR updates the README to reflect the requirement for the location of `nvcc`. 

Thanks for the very extensive library -- the difficulty of doing apples-to-apples comparisons of different quantization techniques in the literature is frustrating.